### PR TITLE
21/03/2022

### DIFF
--- a/src/main/java/jmb/model/BoardLogic.java
+++ b/src/main/java/jmb/model/BoardLogic.java
@@ -64,11 +64,12 @@ public class BoardLogic {
     public void changeTurn() {
         this.whiteTurn= !this.whiteTurn;
         runTurn();
+        view.setPawnsForTurn();
     }
 
     protected void runTurn() {
         dice.tossDice();
-        Logic.view.rollDice();
+        view.rollDice();
     }
 
 
@@ -285,5 +286,13 @@ public class BoardLogic {
 
     public void resetMoveBuffer() {
         this.moveBuffer[0] = this.moveBuffer[1] = UNDEFINED;
+    }
+
+    protected void victoryCheck() {
+        if (squares[15][COL_BLACK_EXIT]!=null) {
+            //TODO
+        } else if (squares[15][COL_WHITE_EXIT]!=null) {
+            //TODO
+        }
     }
 }

--- a/src/main/java/jmb/model/Logic.java
+++ b/src/main/java/jmb/model/Logic.java
@@ -44,8 +44,9 @@ public class Logic implements ILogic{
 
     @Override
     public void placePawnOnPoint(int whichPoint) {
-        board.movePawn(board.getMoveBufferColumn(), board.getMoveBufferRow(),
-                board.searchFirstFreeRow(whichPoint), whichPoint);
+        if (board.movePawn(board.getMoveBufferColumn(), board.getMoveBufferRow(),
+                board.searchFirstFreeRow(whichPoint), whichPoint))
+            board.victoryCheck();
     }
 
     @Override

--- a/src/main/java/jmb/view/BoardView.java
+++ b/src/main/java/jmb/view/BoardView.java
@@ -185,10 +185,10 @@ public class BoardView {
     private Region point_13_R;
 
     @FXML
-    private Rectangle whiteExitRegion;
+    protected Rectangle whiteExitRegion;
 
     @FXML
-    private Rectangle blackExitRegion;
+    protected Rectangle blackExitRegion;
 
     @FXML
     private Rectangle diceTray;

--- a/src/main/java/jmb/view/ConstantsView.java
+++ b/src/main/java/jmb/view/ConstantsView.java
@@ -6,7 +6,7 @@ public class ConstantsView {
 
     public static final double HORIZONTAL_RESIZE_FACTOR = 0.53;         //  La larghezza massima che il tabellone può occupare rispetto alla finestra
     public static final double VERTICAL_RESIZE_FACTOR = 0.9;            //  L'altezza massima che il tabellone può occupare rispetto alla finestra
-    public static final double TURN_DURATION = 2;                       //  La durata in minuti del turno di gioco
+    public static final double TURN_DURATION = 0.25;                       //  La durata in minuti del turno di gioco
     public static final double MAX_BTN_WIDTH = 111;                     //  La larghezza massima del buttone "finish turn"
     public static final double MAX_BTN_HEIGHT = 80;                     //  L'altezza massima dei buttoni piccoli
     public static final double BUTTON_ANCHOR = 10;                      //  Il valore dell'anchor per i tre pulsanti

--- a/src/main/java/jmb/view/IView.java
+++ b/src/main/java/jmb/view/IView.java
@@ -16,4 +16,6 @@ public interface IView {
 
     void setDiceContrast();
 
+    void setPawnsForTurn();
+
 }

--- a/src/main/java/jmb/view/View.java
+++ b/src/main/java/jmb/view/View.java
@@ -44,4 +44,10 @@ public class View implements IView {
         DiceView.setDiceContrast(sceneBoard.diceArray);
     }
 
+    @Override
+    public void setPawnsForTurn() {
+        BoardViewRedraw.redrawPawns(sceneBoard.pawnArrayWHT, sceneBoard.pawnArrayBLK, sceneBoard.regArrayBot,
+                sceneBoard.regArrayTop, sceneBoard.whiteExitRegion, sceneBoard.blackExitRegion);
+    }
+
 }


### PR DESCRIPTION
    BUG: Le mosse in cui si utilizzano più di un dado doppio vengono registrate come se ne utilizzassero uno, nonostante il movimento venga effettuato correttamente - FIXED

    BUG: L’animazione di diceTray non è effettuata correttamente -FIXED

    BUG: Alcune mosse in cui si utilizza più di un dado doppio NON VENGONO EFFETTUATE – FIXED

    I dadi utilizzati per le mosse sono ora visualizzati con contrasto più basso

    Cancellati alcuni TODO

    Tolte alcune istruzioni di TEST

24/03/2022

    BUG : Il tiro dei dadi a volte viene effettuato senza motivo. Capire perché e risolvere

    BUG : Dopo il cambio turno le pedine sbloccate rimangono quelle del giocatore del turno precedente. E’ necessario cliccarne una per far sì che diventino selezionabili quelle giuste. Così è possibile per il giocatore non di turno muovere una pedina sfruttando uno dei dadi dell’avversario
    FIXED – Creato metodo in IView e View per aggiornare lo stato delle pedine nell’interfaccia