### PR TITLE
24/03/2022

### DIFF
--- a/src/main/java/jmb/model/BoardLogic.java
+++ b/src/main/java/jmb/model/BoardLogic.java
@@ -89,6 +89,7 @@ public class BoardLogic {
         possible = dice.checkDice( abs(puntaFinC - puntaInizC));
 
 
+
         //  Si controlla che la mossa sia effettuata nel verso giusto
         if (rightWay(puntaInizC, puntaInizR, puntaFinC) && possible) {
 
@@ -289,10 +290,10 @@ public class BoardLogic {
     }
 
     protected void victoryCheck() {
-        if (squares[15][COL_BLACK_EXIT]!=null) {
-            //TODO
-        } else if (squares[15][COL_WHITE_EXIT]!=null) {
-            //TODO
+        if (squares[14][COL_BLACK_EXIT]!=null) {
+            view.blackWins();
+        } else if (squares[14][COL_WHITE_EXIT]!=null) {
+            view.whiteWins();
         }
     }
 }

--- a/src/main/java/jmb/model/Logic.java
+++ b/src/main/java/jmb/model/Logic.java
@@ -45,8 +45,9 @@ public class Logic implements ILogic{
     @Override
     public void placePawnOnPoint(int whichPoint) {
         if (board.movePawn(board.getMoveBufferColumn(), board.getMoveBufferRow(),
-                board.searchFirstFreeRow(whichPoint), whichPoint))
+                board.searchFirstFreeRow(whichPoint), whichPoint)) {
             board.victoryCheck();
+        }
     }
 
     @Override
@@ -61,6 +62,7 @@ public class Logic implements ILogic{
     @Override
     public void nextTurn() {
         board.changeTurn();
+
     }
 
     @Override

--- a/src/main/java/jmb/view/BoardView.java
+++ b/src/main/java/jmb/view/BoardView.java
@@ -372,11 +372,16 @@ public class BoardView {
     private String name1;
     //      0 e 1 occupate dai dadi standard e 2 e 3 occupate dai dadi doppi
 
+    protected Timeline turnTimer;
+
+    private boolean gameStart = false;
+
 
     @FXML
     protected void nextTurn (ActionEvent event) {
+        turnTimer.stop();
+        turnTimer.play();
         logic.nextTurn();                   // La parte logica esegue il cambio di turno
-        runTimer();                         // Si resetta il timer del turno
         BoardViewRedraw.redrawPawns(pawnArrayWHT, pawnArrayBLK, regArrayBot,                   // Si chiama il ridisegno delle pedine
                                         regArrayTop, whiteExitRegion, blackExitRegion);        // per disabilitare quelle non di turno
         if (logic.getWhichTurn()){
@@ -558,7 +563,7 @@ public class BoardView {
 
     private void changeDimensions() {
 
-        BoardViewRedraw.resizeAll(window, outerRect, boardRect, separator, timerOut, timerIn, polArrayTop,
+        BoardViewRedraw.resizeAll(gameStart, window, outerRect, boardRect, separator, timerOut, timerIn, polArrayTop,
                                     polArrayBot, regArrayTop, regArrayBot, bExit, wExit, whiteExitRegion,
                                     blackExitRegion, dtAnimDone, diceTray, backBTN, finishBTN, menuBTN,
                                     pawnArrayWHT, pawnArrayBLK,
@@ -624,27 +629,19 @@ public class BoardView {
     protected void startGame(ActionEvent event) {
         Iniziamo.setVisible(false);
         logic.firstTurn();
+        gameStart = true;
+        changeDimensions();
         diceTrayAnim();
         runTimer();
-
     }
 
     private void runTimer(){
-        Timeline timeline = new Timeline(
-                new KeyFrame(Duration.ZERO, new KeyValue(timerIn.scaleYProperty(), 1)),
-                new KeyFrame(Duration.minutes(TURN_DURATION), e-> {
-                    logic.nextTurn();
-                    if (logic.getWhichTurn()){
-                        retgioc1.setFill(green);
-                        retgioc2.setFill(red);
-                    }else {
-                        retgioc2.setFill(green);
-                        retgioc1.setFill(red);
-                    }
-                }, new KeyValue(timerIn.scaleYProperty(), 0))
-        );
-        timeline.setCycleCount(Animation.INDEFINITE);
-        timeline.play();
+        turnTimer.setCycleCount(Animation.INDEFINITE);
+        turnTimer.play();
+    }
+
+    protected void gameWon (boolean whiteWon) {
+        
     }
     //--------------------------------------------
     //METODO INITIALIZE
@@ -725,6 +722,14 @@ public class BoardView {
                 this.polArrayBot[i].setStroke(point);
             }
         }
+
+        //Inizializzo il timer del turno
+        turnTimer = new Timeline(
+                        new KeyFrame(Duration.ZERO, new KeyValue(timerIn.scaleYProperty(), 1)),
+                        new KeyFrame(Duration.minutes(TURN_DURATION), e-> {
+                            nextTurn(null);
+                        }, new KeyValue(timerIn.scaleYProperty(), 0))
+        );
 
 
 

--- a/src/main/java/jmb/view/BoardViewRedraw.java
+++ b/src/main/java/jmb/view/BoardViewRedraw.java
@@ -44,8 +44,8 @@ public class BoardViewRedraw {
         return min(usableHeight, usableWidth);
     }
 
-    public static double getMaxBtnWidth(AnchorPane window, Rectangle diceTray) {
-        double maxBtnWidth = window.getWidth() - (diceTray.getLayoutX()+maxDTWidth+(BUTTON_ANCHOR*2));
+    public static double getMaxBtnWidth(AnchorPane window, Rectangle outerRect) {
+        double maxBtnWidth = window.getWidth() - (outerRect.getLayoutX() + outerRect.getWidth() +maxDTWidth+(BUTTON_ANCHOR*2));
         return min(MAX_BTN_WIDTH, maxBtnWidth);
 
     }
@@ -174,13 +174,13 @@ public class BoardViewRedraw {
 
     }
 
-    public static void resizeButtons(Button backBTN, Button finishBTN, Button menuBTN, AnchorPane window, Rectangle diceTray) {
+    public static void resizeButtons(Button backBTN, Button finishBTN, Button menuBTN, AnchorPane window, Rectangle outerRect) {
 
         //  Ridimensiona i Buttoni rispetto alla finestra principale
         //  Larghezza
-        backBTN.setMaxWidth(getMaxBtnWidth(window, diceTray));
-        finishBTN.setMaxWidth(getMaxBtnWidth(window, diceTray));
-        menuBTN.setMaxWidth(getMaxBtnWidth(window, diceTray));
+        backBTN.setMaxWidth(getMaxBtnWidth(window, outerRect));
+        finishBTN.setMaxWidth(getMaxBtnWidth(window, outerRect));
+        menuBTN.setMaxWidth(getMaxBtnWidth(window, outerRect));
         backBTN.setPrefWidth(window.getWidth()*0.15);
         finishBTN.setPrefWidth(backBTN.getPrefWidth());
         menuBTN.setPrefWidth(backBTN.getPrefWidth());
@@ -320,7 +320,7 @@ public class BoardViewRedraw {
 
 
 
-    protected static void resizeAll(AnchorPane window, Rectangle outerRect, Rectangle boardRect,
+    protected static void resizeAll(boolean gameStart, AnchorPane window, Rectangle outerRect, Rectangle boardRect,
                                     Rectangle separator, Rectangle timerOut, Rectangle timerIn,
                                     Polygon[] polArrayTop, Polygon[] polArrayBot, Region[] regArrayTop,
                                     Region[] regArrayBot, boolean bExit, boolean wExit,
@@ -338,10 +338,11 @@ public class BoardViewRedraw {
         resizePawns(pawnArrayWHT, pawnArrayBLK, regArrayBot);
         calcTrayWidth(pawnArrayBLK[0]);
         calcDTWidth(pawnArrayBLK[0]);
-        resizeDiceTray(dtAnimDone, diceTray, outerRect);
-        if (dtAnimDone)
-            resizeDice (diceTray, diceArray);
-        resizeButtons(backBTN, finishBTN, menuBTN, window, diceTray);
+        if (gameStart) {
+            resizeDiceTray(dtAnimDone, diceTray, outerRect);
+            if (dtAnimDone)
+                resizeDice (diceTray, diceArray); }
+        resizeButtons(backBTN, finishBTN, menuBTN, window, outerRect);
         resizeExitRegions(bExit, wExit, whiteExitRegion, blackExitRegion, outerRect);
         redrawPawns(pawnArrayWHT, pawnArrayBLK, regArrayBot, regArrayTop, whiteExitRegion, blackExitRegion);
         resizePaginaPauseIniziamo(window, Pause, Iniziamo);

--- a/src/main/java/jmb/view/ConstantsView.java
+++ b/src/main/java/jmb/view/ConstantsView.java
@@ -6,7 +6,7 @@ public class ConstantsView {
 
     public static final double HORIZONTAL_RESIZE_FACTOR = 0.53;         //  La larghezza massima che il tabellone può occupare rispetto alla finestra
     public static final double VERTICAL_RESIZE_FACTOR = 0.9;            //  L'altezza massima che il tabellone può occupare rispetto alla finestra
-    public static final double TURN_DURATION = 0.25;                       //  La durata in minuti del turno di gioco
+    public static final double TURN_DURATION = 2;                       //  La durata in minuti del turno di gioco
     public static final double MAX_BTN_WIDTH = 111;                     //  La larghezza massima del buttone "finish turn"
     public static final double MAX_BTN_HEIGHT = 80;                     //  L'altezza massima dei buttoni piccoli
     public static final double BUTTON_ANCHOR = 10;                      //  Il valore dell'anchor per i tre pulsanti

--- a/src/main/java/jmb/view/IView.java
+++ b/src/main/java/jmb/view/IView.java
@@ -18,4 +18,8 @@ public interface IView {
 
     void setPawnsForTurn();
 
+    void blackWins();
+
+    void whiteWins();
+
 }

--- a/src/main/java/jmb/view/View.java
+++ b/src/main/java/jmb/view/View.java
@@ -50,4 +50,20 @@ public class View implements IView {
                 sceneBoard.regArrayTop, sceneBoard.whiteExitRegion, sceneBoard.blackExitRegion);
     }
 
+    @Override
+    public void blackWins() {
+        //TODO METTERE LE ISTRUZIONI GIUSTE
+        //  PLACEHOLDER
+        System.out.println("IL NERO VINCE");
+        sceneBoard.gameWon(false);
+    }
+
+    @Override
+    public void whiteWins() {
+        //TODO METTERE LE ISTRUZIONI GIUSTE
+        //  PLACEHOLDER
+        System.out.println("IL BIANCO VINCE");
+        sceneBoard.gameWon(true);
+    }
+
 }

--- a/src/main/resources/jmb/view/GameBoard.fxml
+++ b/src/main/resources/jmb/view/GameBoard.fxml
@@ -2,7 +2,6 @@
 
 <?import javafx.scene.Cursor?>
 <?import javafx.scene.control.Button?>
-<?import javafx.scene.control.TextField?>
 <?import javafx.scene.control.TitledPane?>
 <?import javafx.scene.image.Image?>
 <?import javafx.scene.image.ImageView?>
@@ -15,7 +14,7 @@
 <?import javafx.scene.text.Text?>
 <?import jmb.view.PawnView?>
 
-<AnchorPane fx:id="window" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="847.0" prefWidth="1449.0" xmlns="http://javafx.com/javafx/16" xmlns:fx="http://javafx.com/fxml/1" fx:controller="jmb.view.BoardView">
+<AnchorPane fx:id="window" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="847.0" prefWidth="1449.0" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1" fx:controller="jmb.view.BoardView">
    <cursor>
       <Cursor fx:constant="DEFAULT" />
    </cursor>
@@ -284,11 +283,19 @@
          <Image url="@diceImg/Dado6.png" />
       </image>
    </ImageView>
-   <Circle fx:id="pedgioc1" fill="DODGERBLUE" layoutX="39.0" layoutY="39.0" radius="25.0" stroke="BLACK" strokeType="INSIDE" AnchorPane.leftAnchor="18.0" AnchorPane.topAnchor="23.0" />
-   <TextField editable="false" layoutX="83.0" layoutY="35.0" prefHeight="25.0" prefWidth="107.0" AnchorPane.leftAnchor="83.0" AnchorPane.topAnchor="35.0" />
-   <Circle fx:id="pedgioc2" fill="DODGERBLUE" layoutX="49.0" layoutY="49.0" radius="25.0" stroke="BLACK" strokeType="INSIDE" AnchorPane.rightAnchor="18.0" AnchorPane.topAnchor="23.0" />
+   <Circle fx:id="pedgioc1" fill="DODGERBLUE" layoutX="39.0" layoutY="39.0" radius="25.0" stroke="BLACK" strokeType="INSIDE" strokeWidth="2.0" AnchorPane.leftAnchor="18.0" AnchorPane.topAnchor="23.0" />
+   <Circle fx:id="pedgioc2" fill="DODGERBLUE" layoutX="49.0" layoutY="49.0" radius="25.0" stroke="BLACK" strokeType="INSIDE" strokeWidth="2.0" AnchorPane.rightAnchor="18.0" AnchorPane.topAnchor="23.0" />
    <Rectangle fx:id="retgioc2" arcHeight="5.0" arcWidth="5.0" fill="RED" height="50.0" layoutX="84.0" layoutY="33.0" stroke="BLACK" strokeType="INSIDE" width="124.0" AnchorPane.rightAnchor="74.0" AnchorPane.topAnchor="23.0" />
-   <TextField editable="false" layoutX="93.0" layoutY="45.0" prefHeight="25.0" prefWidth="107.0" AnchorPane.rightAnchor="83.0" AnchorPane.topAnchor="35.0" />
-   <Text fx:id="gioc1" layoutX="125.0" layoutY="52.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Text" textAlignment="CENTER" AnchorPane.leftAnchor="125.0" AnchorPane.topAnchor="39.05078125" />
-   <Text fx:id="gioc2" layoutX="135.0" layoutY="62.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Text" textAlignment="CENTER" AnchorPane.rightAnchor="125.0" AnchorPane.topAnchor="39.05078125" />
+   <AnchorPane layoutX="83.0" layoutY="35.0" AnchorPane.leftAnchor="83.0" AnchorPane.topAnchor="35.0">
+      <children>
+         <Rectangle arcHeight="5.0" arcWidth="5.0" fill="WHITE" height="25.0" stroke="LIGHTGRAY" strokeType="INSIDE" width="107.0" />
+         <Text fx:id="gioc1" layoutY="16.0" strokeType="OUTSIDE" strokeWidth="0.0" text="PROVA" textAlignment="CENTER" wrappingWidth="106.4794921875" />
+      </children>
+   </AnchorPane>
+   <AnchorPane layoutX="199.0" layoutY="37.0" AnchorPane.rightAnchor="83.0" AnchorPane.topAnchor="35.0">
+      <children>
+         <Rectangle arcHeight="5.0" arcWidth="5.0" fill="WHITE" height="25.0" stroke="LIGHTGRAY" strokeType="INSIDE" width="107.0" />
+         <Text fx:id="gioc2" layoutY="16.0" strokeType="OUTSIDE" strokeWidth="0.0" text="PROVA" textAlignment="CENTER" wrappingWidth="106.4794921875" />
+      </children>
+   </AnchorPane>
 </AnchorPane>


### PR DESCRIPTION
    In GameBoard.fxml rimpiazzate le TextView con dei Rectangle

    BUG: Il tiro dei dadi a volte viene effettuato senza motivo. Capire perché e risolvere
    MOTIVO: Ogni volta che l’utente pigiava FINISH TURN il programma creava una nuova Timeline, senza arrestare la vecchia. Perciò, quando la vecchia Timeline arrivava in fondo iniziava un cambio turno non richiesto
    FIXED: Il timer del turno viene creato a livello di classe, al cambio di turno si ferma e si fa ripartire la Timeline, oltre alle altre operazioni di cambio turno

    BUG: Se si ridimensiona la finestra prima di far cominciare la partita il posizionamento dei dadi non viene effettuato correttamente, e il problema sul timer ricompare ingigantito
    SOLUZIONE: Bloccato resizing dei componenti non essenziali prima di cominciare la partita

    Corretti alcuni metodi di resizing per funzionare anche in caso di resizing parziale prepartita

    Tolta un’istruzione runTimer() che ricreava il problema del tiro di dadi non richiesto

    Inseriti i controlli per la vittoria, mancano le istruzioni da eseguire una volta vinta la partita