### PR TITLE
2/04/2022

### DIFF
--- a/src/main/java/jmb/model/LeaderboardLogic.java
+++ b/src/main/java/jmb/model/LeaderboardLogic.java
@@ -74,9 +74,7 @@ public class LeaderboardLogic {
 
                 Iterator<Player> it = arrList.iterator();
                 while(it.hasNext()) {
-                    Player next = it.next();
-                    System.out.println("Sto stampando l'elemento " + next.toString());
-                    Files.writeString(path, next + System.lineSeparator(), CREATE, WRITE, APPEND);
+                    Files.writeString(path, it.next() + System.lineSeparator(), CREATE, WRITE, APPEND);
                 }
             } catch (IOException ioe) {
                 ioe.printStackTrace();

--- a/src/main/java/jmb/model/Logic.java
+++ b/src/main/java/jmb/model/Logic.java
@@ -125,9 +125,9 @@ public class Logic implements ILogic{
             Iterator<String> it = nameList.iterator();
             while (it.hasNext() && output == DECIDING) {
                 String temp = it.next();
-                if (newName1.equals(temp.substring(0, temp.length()-1))) {
+                if (newName1.equals(temp.stripTrailing())) {
                     output = NAME1_ALREADY_PRESENT;
-                } else if (newName2.equals(temp.substring(0, temp.length()-1))) {
+                } else if (newName2.equals(temp.stripTrailing())) {
                     output = NAME2_ALREADY_PRESENT;
                 }
             }

--- a/src/main/java/jmb/view/BoardView.java
+++ b/src/main/java/jmb/view/BoardView.java
@@ -644,10 +644,10 @@ public class BoardView {
     @FXML
     protected void startGame(ActionEvent event) {
         Iniziamo.setVisible(false);
-        logic.firstTurn();
         gameStart = true;
         changeDimensions();
         diceTrayAnim();
+        logic.firstTurn();
         if(turn_duration != 0) {
             runTimer();
         }
@@ -708,10 +708,6 @@ public class BoardView {
     private Button createVictoryButton() {
         Button victoryExit = new Button("Torna al menu");
         window.getChildren().add(victoryExit);
-        victoryExit.setPrefWidth(victoryPanel.getWidth() * 0.3);
-        victoryExit.setPrefHeight(victoryPanel.getHeight() * 0.15);
-        victoryExit.setLayoutY(BoardViewRedraw.calcVExitX(victoryPanel, victoryExit));
-        victoryExit.setLayoutX(BoardViewRedraw.calcVExitY(victoryPanel));
         victoryExit.setOnAction(event -> vaialMainMenu());
         victoryExit.setViewOrder(-16);
 
@@ -735,7 +731,7 @@ public class BoardView {
         Label victoryLabel = new Label();
         window.getChildren().add(victoryLabel);
         String victoryString = "Congratulazioni ";
-        victoryString = victoryString.concat(winner);
+        victoryString = victoryString.concat(winner.stripTrailing());
         victoryString = victoryString.concat("!\nHai vinto la partita!");
         victoryLabel.setText(victoryString);
         victoryLabel.setLayoutY(victoryPanel.getLayoutY() + victoryPanel.getHeight() * 0.2);
@@ -770,6 +766,9 @@ public class BoardView {
 
         crown = createCrownImage();             //  Crea l'ImageView per la corona del vincitore
 
+        gameEndState = true;
+
+        changeDimensions();
 
         Timeline timeline = new Timeline(
                 new KeyFrame(Duration.ZERO, new KeyValue(victoryPanel.opacityProperty(), 0),
@@ -782,8 +781,6 @@ public class BoardView {
         );
         timeline.setCycleCount(1);
         timeline.play();
-
-        gameEndState = true;
 
         logic.addStatsToPlayers(winner, loser);
 

--- a/src/main/java/jmb/view/BoardViewRedraw.java
+++ b/src/main/java/jmb/view/BoardViewRedraw.java
@@ -322,7 +322,7 @@ public class BoardViewRedraw {
     }
 
     private static void resizeVictoryRect (AnchorPane window, Rectangle victoryPanel) {
-        victoryPanel.setWidth(window.getWidth() / 2.5);
+        victoryPanel.setWidth(window.getWidth() / 2);
         victoryPanel.setHeight(window.getHeight()/2.5);
         victoryPanel.setLayoutX((window.getWidth() - victoryPanel.getWidth()) / 2);
         victoryPanel.setLayoutY((window.getHeight() - victoryPanel.getHeight()) / 2);
@@ -334,20 +334,11 @@ public class BoardViewRedraw {
         victoryPawn.setLayoutY(victoryPanel.getLayoutY() + victoryPanel.getHeight() / 2);
     }
 
-    public static double calcVExitX(Rectangle victoryPanel, Button victoryExit) {
-        return victoryPanel.getLayoutX() + (victoryPanel.getWidth() - victoryExit.getWidth()) / 2;
-    }
-
-    public static double calcVExitY(Rectangle victoryPanel) {
-        return victoryPanel.getLayoutY() + (0.66 * victoryPanel.getHeight());
-    }
-
     private static void resizeVictoryExit (Rectangle victoryPanel, Button victoryExit) {
         victoryExit.setPrefWidth(victoryPanel.getWidth() * 0.3);
         victoryExit.setPrefHeight(victoryPanel.getHeight() * 0.15);
-        victoryExit.setLayoutY(calcVExitY(victoryPanel));
-        victoryExit.setLayoutX(calcVExitX(victoryPanel, victoryExit));
-        //TODO BUG: All'inizio viene posizionato male, poi fa scatto in fase resize
+        victoryExit.setLayoutY(victoryPanel.getLayoutY() + (0.66 * victoryPanel.getHeight()));
+        victoryExit.setLayoutX(victoryPanel.getLayoutX() + (victoryPanel.getWidth() - victoryExit.getWidth()) / 2);
     }
 
     private static void resizeVictoryCrown (Circle victoryPawn, ImageView victoryCrown) {
@@ -358,13 +349,13 @@ public class BoardViewRedraw {
 
     private static void resizeVictoryLabel (Rectangle victoryPanel, Label victoryLabel) {
         victoryLabel.setLayoutY(victoryPanel.getLayoutY() + victoryPanel.getHeight() * 0.2);
-        victoryLabel.setLayoutX(victoryPanel.getLayoutX() + victoryPanel.getWidth() * 0.35);
+        victoryLabel.setLayoutX(victoryPanel.getLayoutX() + victoryPanel.getWidth() * 0.25);
         // TODO     Inserire controlli font size
 
     }
 
     //  Metodo per ridimensionare gli elementi del pannello vittoria
-    private static void resizeVictoryPanel (AnchorPane window, Rectangle victoryPanel,
+    protected static void resizeVictoryPanel (AnchorPane window, Rectangle victoryPanel,
                                             Circle victoryPawn, Button victoryExit, ImageView victoryCrown, Label victoryLabel)
     {
         resizeVictoryRect(window, victoryPanel);


### PR DESCRIPTION
    BUG: quando al primo tiro escono risultati doppi i dadi vengono visualizzati male
    FIXED: Posticipato il richiamo di “firstTurn” a dopo l’invocazione dell’animazione di DiceTray

    Visualizzato correttamente il nome del vincitore a fine partita

    Risolto un bug sul controllo dei nomi a inizio partita